### PR TITLE
refactor: Centralizar EntityManager no AbstractDAOImpl e padronizar callbacks de datas nas entidades 

### DIFF
--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/AbstractDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/AbstractDAOImpl.java
@@ -101,4 +101,10 @@ public abstract class AbstractDAOImpl<T> implements DAO<T> {
 			}
 		}
 	}
+
+    public static void closeFactory() {
+        if (emf != null && emf.isOpen()) {
+            emf.close();
+        }
+    }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
@@ -2,7 +2,6 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.AvaliacaoDAO;
 import br.edu.ifpb.es.daw.entities.Avaliacao;
-import jakarta.persistence.EntityManager;
 
 public class AvaliacaoDAOImpl extends AbstractDAOImpl<Avaliacao> implements AvaliacaoDAO {
 

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
@@ -6,7 +6,8 @@ import jakarta.persistence.EntityManager;
 
 public class AvaliacaoDAOImpl extends AbstractDAOImpl<Avaliacao> implements AvaliacaoDAO {
 
-    public AvaliacaoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public AvaliacaoDAOImpl() {
+
+        super(Avaliacao.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/CarrinhoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/CarrinhoDAOImpl.java
@@ -2,12 +2,12 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.CarrinhoDAO;
 import br.edu.ifpb.es.daw.entities.Carrinho;
-import jakarta.persistence.EntityManager;
+
 
 public class CarrinhoDAOImpl extends  AbstractDAOImpl<Carrinho> implements CarrinhoDAO {
 
-    public CarrinhoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public CarrinhoDAOImpl() {
+        super(Carrinho.class);
     }
 
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/CategoriaDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/CategoriaDAOImpl.java
@@ -2,7 +2,6 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.CategoriaDAO;
 import br.edu.ifpb.es.daw.entities.Categoria;
-import jakarta.persistence.EntityManager;
 
 public class CategoriaDAOImpl extends AbstractDAOImpl<Categoria> implements CategoriaDAO {
 

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/CategoriaDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/CategoriaDAOImpl.java
@@ -6,7 +6,8 @@ import jakarta.persistence.EntityManager;
 
 public class CategoriaDAOImpl extends AbstractDAOImpl<Categoria> implements CategoriaDAO {
 
-    public CategoriaDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public CategoriaDAOImpl() {
+
+        super(Categoria.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ClienteDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ClienteDAOImpl.java
@@ -2,11 +2,12 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ClienteDAO;
 import br.edu.ifpb.es.daw.entities.Cliente;
-import jakarta.persistence.EntityManager;
+
 
 public class ClienteDAOImpl extends AbstractDAOImpl<Cliente> implements ClienteDAO {
 
-    public ClienteDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public ClienteDAOImpl() {
+
+        super(Cliente.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/CupomDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/CupomDAOImpl.java
@@ -2,11 +2,12 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.CupomDAO;
 import br.edu.ifpb.es.daw.entities.Cupom;
-import jakarta.persistence.EntityManager;
+
 
 public class CupomDAOImpl extends AbstractDAOImpl<Cupom> implements CupomDAO {
 
-    public CupomDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public CupomDAOImpl() {
+
+        super(Cupom.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/DevolucaoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/DevolucaoDAOImpl.java
@@ -2,11 +2,11 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.DevolucaoDAO;
 import br.edu.ifpb.es.daw.entities.Devolucao;
-import jakarta.persistence.EntityManager;
 
 public class DevolucaoDAOImpl extends AbstractDAOImpl<Devolucao> implements DevolucaoDAO {
 
-    public DevolucaoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public DevolucaoDAOImpl() {
+
+        super(Devolucao.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/EnderecoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/EnderecoDAOImpl.java
@@ -2,11 +2,11 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.EnderecoDAO;
 import br.edu.ifpb.es.daw.entities.Endereco;
-import jakarta.persistence.EntityManager;
 
 public class EnderecoDAOImpl extends AbstractDAOImpl<Endereco> implements EnderecoDAO {
 
-    public EnderecoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public EnderecoDAOImpl() {
+
+        super(Endereco.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/EntregaDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/EntregaDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.EntregaDAO;
 import br.edu.ifpb.es.daw.entities.Entrega;
-import jakarta.persistence.EntityManager;
 
 public class EntregaDAOImpl extends AbstractDAOImpl<Entrega> implements EntregaDAO {
 
-    public EntregaDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public EntregaDAOImpl() {
+        super(Entrega.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemCarrinhoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemCarrinhoDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ItemCarrinhoDAO;
 import br.edu.ifpb.es.daw.entities.ItemCarrinho;
-import jakarta.persistence.EntityManager;
 
 public class ItemCarrinhoDAOImpl extends AbstractDAOImpl<ItemCarrinho> implements ItemCarrinhoDAO {
 
-    public ItemCarrinhoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public ItemCarrinhoDAOImpl() {
+        super(ItemCarrinho.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemPedidoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemPedidoDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ItemPedidoDAO;
 import br.edu.ifpb.es.daw.entities.ItemPedido;
-import jakarta.persistence.EntityManager;
 
 public class ItemPedidoDAOImpl extends AbstractDAOImpl<ItemPedido> implements ItemPedidoDAO {
 
-    public ItemPedidoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public ItemPedidoDAOImpl() {
+        super(ItemPedido.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/PagamentoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/PagamentoDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.PagamentoDAO;
 import br.edu.ifpb.es.daw.entities.Pagamento;
-import jakarta.persistence.EntityManager;
 
 public class PagamentoDAOImpl extends AbstractDAOImpl<Pagamento> implements PagamentoDAO {
 
-    public PagamentoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public PagamentoDAOImpl() {
+        super(Pagamento.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/PedidoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/PedidoDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.PedidoDAO;
 import br.edu.ifpb.es.daw.entities.Pedido;
-import jakarta.persistence.EntityManager;
 
 public class PedidoDAOImpl extends AbstractDAOImpl<Pedido> implements PedidoDAO {
 
-    public PedidoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public PedidoDAOImpl() {
+        super(Pedido.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ProdutoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ProdutoDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ProdutoDAO;
 import br.edu.ifpb.es.daw.entities.Produto;
-import jakarta.persistence.EntityManager;
 
 public class ProdutoDAOImpl extends AbstractDAOImpl<Produto> implements ProdutoDAO {
 
-    public ProdutoDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public ProdutoDAOImpl() {
+        super(Produto.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/VendedorDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/VendedorDAOImpl.java
@@ -2,11 +2,10 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.VendedorDAO;
 import br.edu.ifpb.es.daw.entities.Vendedor;
-import jakarta.persistence.EntityManager;
 
 public class VendedorDAOImpl extends AbstractDAOImpl<Vendedor> implements VendedorDAO {
 
-    public VendedorDAOImpl(EntityManager entityManager) {
-        super(entityManager);
+    public VendedorDAOImpl() {
+        super(Vendedor.class);
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Avaliacao.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Avaliacao.java
@@ -11,7 +11,6 @@ public class Avaliacao {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_avaliacao")
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Categoria.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Categoria.java
@@ -10,7 +10,6 @@ public class Categoria {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_categoria")
     private Long id;
 
     @Column(length = 50, unique = true, nullable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Cliente.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Cliente.java
@@ -12,7 +12,6 @@ public class Cliente {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cliente_seq")
     @SequenceGenerator(name = "cliente_seq", sequenceName = "seq_cliente_id", allocationSize = 1)
-    @Column(name = "id_cliente")
     private Long id;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Cupom.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Cupom.java
@@ -12,7 +12,6 @@ public class Cupom {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_cupom")
     private Long id;
 
     @Column(length = 20, unique = true, nullable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Cupom.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Cupom.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 
+
 @Entity
 @Table(name = "cupom")
 public class Cupom {

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Devolucao.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Devolucao.java
@@ -11,7 +11,6 @@ public class Devolucao {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_devolucao")
     private Long id;
 
     @Column(name = "data_devolucao", insertable = false, updatable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Devolucao.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Devolucao.java
@@ -13,7 +13,7 @@ public class Devolucao {
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
     private Long id;
 
-    @Column(name = "data_devolucao", insertable = false, updatable = false)
+    @Column(name = "data_devolucao", nullable = false ,updatable = false)
     private LocalDateTime dataDevolucao;
 
     @Column(nullable = false, length = 1000)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Endereco.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Endereco.java
@@ -10,7 +10,6 @@ public class Endereco {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_endereco")
     private Long id;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Entrega.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Entrega.java
@@ -11,7 +11,6 @@ public class Entrega {
 
     @Id
     @GeneratedValue( strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_entrega")
     private Long id;
 
     @Column(length = 50)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Entrega.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Entrega.java
@@ -29,6 +29,17 @@ public class Entrega {
     @Column(name = "data_entrega_prevista")
     private LocalDateTime dataEntregaPrevista;
 
+    @PrePersist
+    protected void onCreate() {
+        this.dataEnvio = LocalDateTime.now();
+        this.dataEntregaPrevista = LocalDateTime.now().plusDays(7);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.dataEntregaPrevista = LocalDateTime.now().plusDays(7);
+    }
+
     public Entrega() {
     }
 

--- a/src/main/java/br/edu/ifpb/es/daw/entities/ItemCarrinho.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/ItemCarrinho.java
@@ -11,7 +11,6 @@ public class ItemCarrinho {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_item_carrinho")
     private Long id;
 
     @Column(name = "preco_unitario", nullable = false, precision = 10, scale = 2)

--- a/src/main/java/br/edu/ifpb/es/daw/entities/ItemPedido.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/ItemPedido.java
@@ -11,7 +11,6 @@ public class ItemPedido {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @Column(name = "id_item_pedido")
     private Long id;
 
     @Column(name = "preco_unitario", nullable = false, precision = 10, scale = 2)

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainAvaliacaoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainAvaliacaoDeleteAll.java
@@ -1,23 +1,28 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.AvaliacaoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.AvaliacaoDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainAvaliacaoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try{
 
-        AvaliacaoDAO dao = new AvaliacaoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            AvaliacaoDAO dao = new AvaliacaoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todas as avaliações foram removidas!");
+            System.out.println("Todas as avaliações foram removidas!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainAvaliacaoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainAvaliacaoSave.java
@@ -1,6 +1,7 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.AvaliacaoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.AvaliacaoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Avaliacao;
 import br.edu.ifpb.es.daw.util.JPAUtil;
@@ -11,19 +12,26 @@ public class MainAvaliacaoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try{
 
-        AvaliacaoDAO dao = new AvaliacaoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Avaliacao avaliacao = new Avaliacao();
+            AvaliacaoDAO dao = new AvaliacaoDAOImpl();
 
-        avaliacao.setNota(5);
-        avaliacao.setComentario("Muito bom!");
+            Avaliacao avaliacao = new Avaliacao();
 
-        dao.save(avaliacao);
+            avaliacao.setNota(5);
+            avaliacao.setComentario("Muito bom!");
 
-        em.close();
+            dao.save(avaliacao);
 
-        System.out.println("Avaliação salva com sucesso!");
+            System.out.println("Avaliação salva com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoDeleteAll.java
@@ -1,22 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CarrinhoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CarrinhoDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
+
 
 public class MainCarrinhoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
+            AbstractDAOImpl.initialize("daw");
 
-        CarrinhoDAO dao = new CarrinhoDAOImpl(em);
+            CarrinhoDAO dao = new CarrinhoDAOImpl();
 
-        dao.deleteAll();
+            dao.deleteAll();
 
-        em.close();
+            System.out.println("Todos os carrinhos foram apagados!");
 
-        System.out.println("Todos os carrinhos foram apagados!");
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
@@ -6,8 +6,6 @@ import br.edu.ifpb.es.daw.dao.impl.CarrinhoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Carrinho;
 
 
-
-
 public class MainCarrinhoSave {
 
     public static void main(String[] args) {

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
@@ -1,26 +1,35 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CarrinhoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CarrinhoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Carrinho;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
+
+
+
 
 public class MainCarrinhoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try{
 
-        CarrinhoDAO dao = new CarrinhoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Carrinho carrinho = new Carrinho();
+            CarrinhoDAO dao = new CarrinhoDAOImpl();
 
-        dao.save(carrinho);
+            Carrinho carrinho = new Carrinho();
 
-        em.close();
+            dao.save(carrinho);
 
-        System.out.println("Carrinho salvo com sucesso");
+            System.out.println("Carrinho salvo com sucesso");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
 
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaDeleteAll.java
@@ -1,23 +1,29 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CategoriaDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CategoriaDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainCategoriaDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        CategoriaDAO dao = new CategoriaDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            CategoriaDAO dao = new CategoriaDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todas as categorias foram removidas!");
+            System.out.println("Todas as categorias foram removidas!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaSave.java
@@ -4,9 +4,6 @@ import br.edu.ifpb.es.daw.dao.CategoriaDAO;
 import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CategoriaDAOImpl;
 import br.edu.ifpb.es.daw.entities.Categoria;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainCategoriaSave {
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCategoriaSave.java
@@ -1,6 +1,7 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CategoriaDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CategoriaDAOImpl;
 import br.edu.ifpb.es.daw.entities.Categoria;
 import br.edu.ifpb.es.daw.util.JPAUtil;
@@ -11,20 +12,28 @@ public class MainCategoriaSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        CategoriaDAO dao = new CategoriaDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Categoria categoria = new Categoria();
+            CategoriaDAO dao = new CategoriaDAOImpl();
 
-        categoria.setNome("Categoria_" + System.nanoTime());
+            Categoria categoria = new Categoria();
 
-        categoria.setDescricao("Descrição de teste");
+            categoria.setNome("Categoria_" + System.nanoTime());
 
-        dao.save(categoria);
+            categoria.setDescricao("Descrição de teste");
 
-        em.close();
+            dao.save(categoria);
 
-        System.out.println("Categoria salva com sucesso!");
+            System.out.println("Categoria salva com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainClienteDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainClienteDeleteAll.java
@@ -1,23 +1,29 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ClienteDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ClienteDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainClienteDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try{
 
-        ClienteDAO dao = new ClienteDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            ClienteDAO dao = new ClienteDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os clientes foram removidos!");
+            System.out.println("Todos os clientes foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainClienteSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainClienteSave.java
@@ -1,33 +1,38 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ClienteDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ClienteDAOImpl;
 import br.edu.ifpb.es.daw.entities.Cliente;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainClienteSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ClienteDAO dao = new ClienteDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Cliente cliente = new Cliente();
+            ClienteDAO dao = new ClienteDAOImpl();
 
-        cliente.setNome("João da Silva");
+            Cliente cliente = new Cliente();
 
-        cliente.setEmail("joao" + System.nanoTime() + "@gmail.com");
+            cliente.setNome("João da Silva");
 
-        cliente.setSenha("123456");
-        cliente.setTelefone("83999999999");
+            cliente.setEmail("joao" + System.nanoTime() + "@gmail.com");
 
-        dao.save(cliente);
+            cliente.setSenha("123456");
+            cliente.setTelefone("83999999999");
 
-        em.close();
+            dao.save(cliente);
 
-        System.out.println("Cliente salvo com sucesso!");
+            System.out.println("Cliente salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCupomDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCupomDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CupomDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CupomDAOImpl;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainCupomDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        CupomDAO dao = new CupomDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            CupomDAO dao = new CupomDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os cupons foram removidos!");
+            System.out.println("Todos os cupons foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCupomSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCupomSave.java
@@ -1,12 +1,10 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.CupomDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.CupomDAOImpl;
 import br.edu.ifpb.es.daw.entities.Cupom;
 import br.edu.ifpb.es.daw.entities.StatusCupom;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,22 +13,28 @@ public class MainCupomSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        CupomDAO dao = new CupomDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Cupom cupom = new Cupom();
+            CupomDAO dao = new CupomDAOImpl();
 
-        cupom.setCodigo("C" + (System.nanoTime() % 1000000000));
+            Cupom cupom = new Cupom();
 
-        cupom.setValorDesconto(new BigDecimal("50.00"));
-        cupom.setDataExpiracao(LocalDate.now().plusDays(30));
-        cupom.setStatus(StatusCupom.ATIVO);
+            cupom.setCodigo("C" + (System.nanoTime() % 1000000000));
 
-        dao.save(cupom);
+            cupom.setValorDesconto(new BigDecimal("50.00"));
+            cupom.setDataExpiracao(LocalDate.now().plusDays(30));
+            cupom.setStatus(StatusCupom.ATIVO);
 
-        em.close();
+            dao.save(cupom);
 
-        System.out.println("Cupom salvo com sucesso!");
+            System.out.println("Cupom salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.DevolucaoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.DevolucaoDAOImpl;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainDevolucaoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        DevolucaoDAO dao = new DevolucaoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            DevolucaoDAO dao = new DevolucaoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todas as devoluções foram removidas!");
+            System.out.println("Todas as devoluções foram removidas!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoSave.java
@@ -1,32 +1,34 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.DevolucaoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.DevolucaoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Devolucao;
-
 import br.edu.ifpb.es.daw.entities.StatusDevolucao;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
-
-import java.math.BigDecimal;
 
 public class MainDevolucaoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        DevolucaoDAO dao = new DevolucaoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Devolucao devolucao = new Devolucao();
+            DevolucaoDAO dao = new DevolucaoDAOImpl();
 
-        devolucao.setMotivo("Produto com defeito");
-        devolucao.setStatus(StatusDevolucao.APROVADA);
+            Devolucao devolucao = new Devolucao();
 
-        dao.save(devolucao);
+            devolucao.setMotivo("Produto com defeito");
+            devolucao.setStatus(StatusDevolucao.APROVADA);
 
-        em.close();
+            dao.save(devolucao);
 
-        System.out.println("Devolução salva com sucesso!");
+            System.out.println("Devolução salva com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoDeleteAll.java
@@ -1,23 +1,28 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.EnderecoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EnderecoDAOImpl;
 
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainEnderecoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        EnderecoDAO dao = new EnderecoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            EnderecoDAO dao = new EnderecoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os endereços foram removidos!");
+            System.out.println("Todos os endereços foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoSave.java
@@ -1,33 +1,38 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.EnderecoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EnderecoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Endereco;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainEnderecoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        EnderecoDAO dao = new EnderecoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Endereco endereco = new Endereco();
+            EnderecoDAO dao = new EnderecoDAOImpl();
 
-        endereco.setRua("Rua das Flores");
-        endereco.setNumero("123");
-        endereco.setComplemento("Apto 101");
-        endereco.setCep("58000000");
-        endereco.setCidade("João Pessoa");
-        endereco.setEstado("PB");
+            Endereco endereco = new Endereco();
 
-        dao.save(endereco);
+            endereco.setRua("Rua das Flores");
+            endereco.setNumero("123");
+            endereco.setComplemento("Apto 101");
+            endereco.setCep("58000000");
+            endereco.setCidade("João Pessoa");
+            endereco.setEstado("PB");
 
-        em.close();
+            dao.save(endereco);
 
-        System.out.println("Endereço salvo com sucesso!");
+            System.out.println("Endereço salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.EntregaDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EntregaDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainEntregaDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        EntregaDAO dao = new EntregaDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            EntregaDAO dao = new EntregaDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todas as entregas foram removidas!");
+            System.out.println("Todas as entregas foram removidas!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaSave.java
@@ -1,12 +1,10 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.EntregaDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EntregaDAOImpl;
 import br.edu.ifpb.es.daw.entities.Entrega;
 import br.edu.ifpb.es.daw.entities.StatusEntrega;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 import java.time.LocalDateTime;
 
@@ -14,25 +12,31 @@ public class MainEntregaSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        EntregaDAO dao = new EntregaDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Entrega entrega = new Entrega();
+            EntregaDAO dao = new EntregaDAOImpl();
 
-        entrega.setTransportadora("Correios");
+            Entrega entrega = new Entrega();
 
-        entrega.setCodigoRastreamento("BR" + System.nanoTime());
+            entrega.setTransportadora("Correios");
 
-        entrega.setStatusEntrega(StatusEntrega.SAIU_PARA_ENTREGA);
+            entrega.setCodigoRastreamento("BR" + System.nanoTime());
 
-        entrega.setDataEnvio(LocalDateTime.now());
-        entrega.setDataEntregaPrevista(LocalDateTime.now().plusDays(7));
+            entrega.setStatusEntrega(StatusEntrega.SAIU_PARA_ENTREGA);
 
-        dao.save(entrega);
+            entrega.setDataEnvio(LocalDateTime.now());
+            entrega.setDataEntregaPrevista(LocalDateTime.now().plusDays(7));
 
-        em.close();
+            dao.save(entrega);
 
-        System.out.println("Entrega salva com sucesso!");
+            System.out.println("Entrega salva com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ItemCarrinhoDAO;
-import br.edu.ifpb.es.daw.dao.impl.*;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.ItemCarrinhoDAOImpl;
 
 public class MainItemCarrinhoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ItemCarrinhoDAO dao = new ItemCarrinhoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            ItemCarrinhoDAO dao = new ItemCarrinhoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os itens do carrinho foram apagados!");
+            System.out.println("Todos os itens do carrinho foram apagados!");
 
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoSave.java
@@ -1,30 +1,36 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ItemCarrinhoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ItemCarrinhoDAOImpl;
 import br.edu.ifpb.es.daw.entities.ItemCarrinho;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 
 public class MainItemCarrinhoSave {
 
     public static void main(String[] args) {
-        EntityManager em = JPAUtil.getEntityManager();
 
-        ItemCarrinhoDAO dao = new ItemCarrinhoDAOImpl(em);
+        try {
 
-        ItemCarrinho itemCarrinho = new ItemCarrinho();
+            AbstractDAOImpl.initialize("daw");
 
-        itemCarrinho.setPrecoUnitario(BigDecimal.valueOf(100.25));
+            ItemCarrinhoDAO dao = new ItemCarrinhoDAOImpl();
 
-        itemCarrinho.setQuantidade(50);
+            ItemCarrinho itemCarrinho = new ItemCarrinho();
 
-        dao.save(itemCarrinho);
+            itemCarrinho.setPrecoUnitario(BigDecimal.valueOf(100.25));
 
-        em.close();
+            itemCarrinho.setQuantidade(50);
 
-        System.out.println("Item do carrinho salvo");
+            dao.save(itemCarrinho);
+
+            System.out.println("Item do carrinho salvo");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ItemPedidoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ItemPedidoDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainItemPedidoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ItemPedidoDAO dao = new ItemPedidoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            ItemPedidoDAO dao = new ItemPedidoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
+            System.out.println("Todos os itens de pedido foram apagados!");
 
-        System.out.println("Todos os carrinhos foram apagados!");
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoSave.java
@@ -1,10 +1,9 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ItemPedidoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ItemPedidoDAOImpl;
 import br.edu.ifpb.es.daw.entities.ItemPedido;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 
@@ -12,20 +11,26 @@ public class MainItemPedidoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ItemPedidoDAO dao = new ItemPedidoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        ItemPedido itemPedido = new ItemPedido();
+            ItemPedidoDAO dao = new ItemPedidoDAOImpl();
 
-        itemPedido.setPrecoUnitario(BigDecimal.valueOf(50.50));
+            ItemPedido itemPedido = new ItemPedido();
 
-        itemPedido.setQuantidade(30);
+            itemPedido.setPrecoUnitario(BigDecimal.valueOf(50.50));
 
-        dao.save(itemPedido);
+            itemPedido.setQuantidade(30);
 
-        em.close();
+            dao.save(itemPedido);
 
-        System.out.println("Item pedido salvo com sucesso");
+            System.out.println("Item pedido salvo com sucesso");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.PagamentoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.PagamentoDAOImpl;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainPagamentoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        PagamentoDAO dao = new PagamentoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            PagamentoDAO dao = new PagamentoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os pagamentos foram removidos!");
+            System.out.println("Todos os pagamentos foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoSave.java
@@ -1,13 +1,11 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.PagamentoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.PagamentoDAOImpl;
 import br.edu.ifpb.es.daw.entities.MetodoPagamento;
 import br.edu.ifpb.es.daw.entities.Pagamento;
-
 import br.edu.ifpb.es.daw.entities.StatusPagamento;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 
@@ -15,20 +13,26 @@ public class MainPagamentoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        PagamentoDAO dao = new PagamentoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Pagamento pagamento = new Pagamento();
+            PagamentoDAO dao = new PagamentoDAOImpl();
 
-        pagamento.setMetodo(MetodoPagamento.PIX);
-        pagamento.setStatus(StatusPagamento.APROVADO);
-        pagamento.setValorPago(new BigDecimal("250.00"));
+            Pagamento pagamento = new Pagamento();
 
-        dao.save(pagamento);
+            pagamento.setMetodo(MetodoPagamento.PIX);
+            pagamento.setStatus(StatusPagamento.APROVADO);
+            pagamento.setValorPago(new BigDecimal("250.00"));
 
-        em.close();
+            dao.save(pagamento);
 
-        System.out.println("Pagamento salvo com sucesso!");
+            System.out.println("Pagamento salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainPedidoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainPedidoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.PedidoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 public class MainPedidoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        PedidoDAO dao = new PedidoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            PedidoDAO dao = new PedidoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os pedidos foram removidos!");
+            System.out.println("Todos os pedidos foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainPedidoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainPedidoSave.java
@@ -1,13 +1,10 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.PedidoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Pedido;
-import br.edu.ifpb.es.daw.entities.StatusCupom;
 import br.edu.ifpb.es.daw.entities.StatusPedido;
-import br.edu.ifpb.es.daw.util.JPAUtil;
-
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 
@@ -15,19 +12,25 @@ public class MainPedidoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        PedidoDAO dao = new PedidoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Pedido pedido = new Pedido();
+            PedidoDAO dao = new PedidoDAOImpl();
 
-        pedido.setValorTotal(new BigDecimal("500.00"));
-        pedido.setStatus(StatusPedido.CRIADO);
+            Pedido pedido = new Pedido();
 
-        dao.save(pedido);
+            pedido.setValorTotal(new BigDecimal("500.00"));
+            pedido.setStatus(StatusPedido.CRIADO);
 
-        em.close();
+            dao.save(pedido);
 
-        System.out.println("Pedido salvo com sucesso!");
+            System.out.println("Pedido salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainProdutoDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainProdutoDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ProdutoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ProdutoDAOImpl;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainProdutoDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ProdutoDAO dao = new ProdutoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            ProdutoDAO dao = new ProdutoDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os produtos foram removidos!");
+            System.out.println("Todos os produtos foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainProdutoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainProdutoSave.java
@@ -1,11 +1,9 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.ProdutoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.ProdutoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Produto;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 
@@ -13,21 +11,27 @@ public class MainProdutoSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        ProdutoDAO dao = new ProdutoDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Produto produto = new Produto();
+            ProdutoDAO dao = new ProdutoDAOImpl();
 
-        produto.setNome("Notebook");
-        produto.setDescricao("Notebook Dell i7");
-        produto.setEstoque(10);
-        produto.setPreco(new BigDecimal("3500.00"));
+            Produto produto = new Produto();
 
-        dao.save(produto);
+            produto.setNome("Notebook");
+            produto.setDescricao("Notebook Dell i7");
+            produto.setEstoque(10);
+            produto.setPreco(new BigDecimal("3500.00"));
 
-        em.close();
+            dao.save(produto);
 
-        System.out.println("Produto salvo com sucesso!");
+            System.out.println("Produto salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainVendedorDeleteAll.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainVendedorDeleteAll.java
@@ -1,23 +1,27 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.VendedorDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.VendedorDAOImpl;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainVendedorDeleteAll {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        VendedorDAO dao = new VendedorDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        dao.deleteAll();
+            VendedorDAO dao = new VendedorDAOImpl();
 
-        em.close();
+            dao.deleteAll();
 
-        System.out.println("Todos os vendedores foram removidos!");
+            System.out.println("Todos os vendedores foram removidos!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainVendedorSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainVendedorSave.java
@@ -1,30 +1,34 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.VendedorDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.VendedorDAOImpl;
 import br.edu.ifpb.es.daw.entities.Vendedor;
-
-import br.edu.ifpb.es.daw.util.JPAUtil;
-import jakarta.persistence.EntityManager;
 
 public class MainVendedorSave {
 
     public static void main(String[] args) {
 
-        EntityManager em = JPAUtil.getEntityManager();
+        try {
 
-        VendedorDAO dao = new VendedorDAOImpl(em);
+            AbstractDAOImpl.initialize("daw");
 
-        Vendedor vendedor = new Vendedor();
+            VendedorDAO dao = new VendedorDAOImpl();
 
-        vendedor.setRazaoSocial("Empresa Teste");
+            Vendedor vendedor = new Vendedor();
 
-        vendedor.setCnpjCpf("V" + (System.nanoTime() % 1000000000));
+            vendedor.setRazaoSocial("Empresa Teste");
 
-        dao.save(vendedor);
+            vendedor.setCnpjCpf("V" + (System.nanoTime() % 1000000000));
 
-        em.close();
+            dao.save(vendedor);
 
-        System.out.println("Vendedor salvo com sucesso!");
+            System.out.println("Vendedor salvo com sucesso!");
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
     }
 }


### PR DESCRIPTION
 ## Summary                                                

  - **Centralização do `EntityManager` no `AbstractDAOImpl`**: todas as DAOsImpl agora herdam o gerenciamento de `EntityManager` e transações da classe abstrata, eliminando duplicação de código. Os construtores das DAOs foram simplificados para receberem apenas `Class<T>` ao invés de `EntityManager`.
  - **Padronização das classes `Main*`**: todas as 24 classes de teste foram migradas para o padrão `AbstractDAOImpl.initialize("daw")` / `AbstractDAOImpl.closeFactory()`,        
  removendo o uso direto de `JPAUtil` e `EntityManager`.
  - **Callbacks `@PrePersist`/`@PreUpdate` nas entidades**: adicionados em `Entrega.java` para garantir que campos de data (`dataEnvio`, `dataEntregaPrevista`) não fiquem nulos ao salvar. As demais entidades (`Cliente`, `Produto`, `Carrinho`, `Pedido`, `Pagamento`, `Devolucao`, `Avaliacao`) já possuíam os callbacks.
  - **Limpeza de imports não usados**: removidos imports de `EntityManager` e `JPAUtil` em todas as DAOsImpl e classes Main afetadas.

  **52 arquivos alterados**: 16 DAOsImpl, 10 entidades, 24 classes Main, 1 AbstractDAOImpl, 1 Cupom.

  ## Test plan

  - [x] Executar cada classe `Main*Save` e verificar se o registro é persistido sem erros
  - [x] Executar cada classe `Main*DeleteAll` e verificar se os registros são removidos
  - [x] Verificar se os campos de data (ex: `dataEnvio` em `Entrega`) são populados automaticamente
  - [x] Confirmar que nenhuma DAOImpl instancia `EntityManager` diretamente

