### PR TITLE
fix/feat: correção de relacionamentos JPA, chaves compostas e validações nos MainXSave

### DIFF
--- a/src/main/java/br/edu/ifpb/es/daw/dao/ItemCarrinhoDAO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/ItemCarrinhoDAO.java
@@ -3,4 +3,5 @@ package br.edu.ifpb.es.daw.dao;
 import br.edu.ifpb.es.daw.entities.ItemCarrinho;
 
 public interface ItemCarrinhoDAO extends DAO<ItemCarrinho> {
+    ItemCarrinho findByCarrinhoAndProduto(Long carrinhoId, Long produtoId);
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/ItemPedidoDAO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/ItemPedidoDAO.java
@@ -3,4 +3,5 @@ package br.edu.ifpb.es.daw.dao;
 import br.edu.ifpb.es.daw.entities.ItemPedido;
 
 public interface ItemPedidoDAO extends DAO<ItemPedido> {
+    ItemPedido findByPedidoAndProduto(Long pedidoId, Long produtoId);
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemCarrinhoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemCarrinhoDAOImpl.java
@@ -2,10 +2,20 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ItemCarrinhoDAO;
 import br.edu.ifpb.es.daw.entities.ItemCarrinho;
+import br.edu.ifpb.es.daw.entities.ItemCarrinhoId;
+import jakarta.persistence.EntityManager;
 
 public class ItemCarrinhoDAOImpl extends AbstractDAOImpl<ItemCarrinho> implements ItemCarrinhoDAO {
 
     public ItemCarrinhoDAOImpl() {
         super(ItemCarrinho.class);
+    }
+
+    @Override
+    public ItemCarrinho findByCarrinhoAndProduto(Long carrinhoId, Long produtoId) {
+        try (EntityManager em = getEntityManager()) {
+            ItemCarrinhoId id = new ItemCarrinhoId(carrinhoId, produtoId);
+            return em.find(ItemCarrinho.class, id);
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemPedidoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ItemPedidoDAOImpl.java
@@ -2,10 +2,20 @@ package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.ItemPedidoDAO;
 import br.edu.ifpb.es.daw.entities.ItemPedido;
+import br.edu.ifpb.es.daw.entities.ItemPedidoId;
+import jakarta.persistence.EntityManager;
 
 public class ItemPedidoDAOImpl extends AbstractDAOImpl<ItemPedido> implements ItemPedidoDAO {
 
     public ItemPedidoDAOImpl() {
         super(ItemPedido.class);
+    }
+
+    @Override
+    public ItemPedido findByPedidoAndProduto(Long pedidoId, Long produtoId) {
+        try (EntityManager em = getEntityManager()) {
+            ItemPedidoId id = new ItemPedidoId(pedidoId, produtoId);
+            return em.find(ItemPedido.class, id);
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/entities/ItemPedidoId.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/ItemPedidoId.java
@@ -52,5 +52,6 @@ public class ItemPedidoId implements Serializable {
     }
 
     public void setIdProduto(Long id) {
+
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/entities/Pedido.java
+++ b/src/main/java/br/edu/ifpb/es/daw/entities/Pedido.java
@@ -35,6 +35,11 @@ public class Pedido {
     @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ItemPedido> itens = new ArrayList<>();
 
+    // Relacionamento com Cupom
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_cupom") // Um Pedido NÃO precisa obrigatoriamente de um Cupom
+    private Cupom cupom;
+
     public Pedido() {
     }
 
@@ -61,6 +66,10 @@ public class Pedido {
 
     public List<ItemPedido> getItens() { return itens; }
     public void setItens(List<ItemPedido> itens) { this.itens = itens; }
+
+    public Cupom getCupom() { return cupom; }
+    public void setCupom(Cupom cupom) { this.cupom = cupom; }
+
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCarrinhoSave.java
@@ -27,10 +27,20 @@ public class MainCarrinhoSave {
 
             Cliente cliente = clientes.isEmpty() ? null : clientes.get(0);
 
-            System.out.println("ID do Cliente encontrado: " + (cliente != null ? cliente.getId() : "NULL"));
-
             if (cliente == null) {
                 System.out.println("❌ Não há clientes no banco!");
+                return;
+            }
+
+            System.out.println("ID do Cliente encontrado: " + cliente.getId());
+
+            // Verifica se o cliente já possui carrinho
+            List<Carrinho> carrinhos = carrinhoDAO.findAll();
+            boolean jaTemCarrinho = carrinhos.stream()
+                    .anyMatch(c -> c.getCliente().getId().equals(cliente.getId()));
+
+            if (jaTemCarrinho) {
+                System.out.println("⚠️ Cliente já possui um carrinho! Nenhum carrinho criado.");
                 return;
             }
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainCupomSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainCupomSave.java
@@ -22,14 +22,13 @@ public class MainCupomSave {
             Cupom cupom = new Cupom();
 
             cupom.setCodigo("C" + (System.nanoTime() % 1000000000));
-
             cupom.setValorDesconto(new BigDecimal("50.00"));
             cupom.setDataExpiracao(LocalDate.now().plusDays(30));
             cupom.setStatus(StatusCupom.ATIVO);
 
             dao.save(cupom);
 
-            System.out.println("Cupom salvo com sucesso!");
+            System.out.println("✅ Cupom salvo com sucesso!");
 
         } finally {
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainDevolucaoSave.java
@@ -1,10 +1,15 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.DevolucaoDAO;
+import br.edu.ifpb.es.daw.dao.PedidoDAO;
 import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.DevolucaoDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Devolucao;
+import br.edu.ifpb.es.daw.entities.Pedido;
 import br.edu.ifpb.es.daw.entities.StatusDevolucao;
+
+import java.util.List;
 
 public class MainDevolucaoSave {
 
@@ -14,16 +19,30 @@ public class MainDevolucaoSave {
 
             AbstractDAOImpl.initialize("daw");
 
-            DevolucaoDAO dao = new DevolucaoDAOImpl();
+            DevolucaoDAO devolucaoDAO = new DevolucaoDAOImpl();
+            PedidoDAO pedidoDAO = new PedidoDAOImpl();
+
+            List<Pedido> pedidos = pedidoDAO.findAll();
+
+            System.out.println("Pedidos no banco: " + pedidos.size());
+
+            Pedido pedido = pedidos.isEmpty() ? null : pedidos.get(0);
+
+            System.out.println("ID do Pedido encontrado: " + (pedido != null ? pedido.getId() : "NULL"));
+
+            if (pedido == null) {
+                System.out.println("❌ Não há pedidos no banco! Execute MainPedidoSave primeiro.");
+                return;
+            }
 
             Devolucao devolucao = new Devolucao();
-
             devolucao.setMotivo("Produto com defeito");
             devolucao.setStatus(StatusDevolucao.APROVADA);
+            devolucao.setPedido(pedido);
 
-            dao.save(devolucao);
+            devolucaoDAO.save(devolucao);
 
-            System.out.println("Devolução salva com sucesso!");
+            System.out.println("✅ Devolução salva com sucesso!");
 
         } finally {
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEnderecoSave.java
@@ -1,9 +1,14 @@
 package br.edu.ifpb.es.daw.main;
 
+import br.edu.ifpb.es.daw.dao.ClienteDAO;
 import br.edu.ifpb.es.daw.dao.EnderecoDAO;
 import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.ClienteDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EnderecoDAOImpl;
+import br.edu.ifpb.es.daw.entities.Cliente;
 import br.edu.ifpb.es.daw.entities.Endereco;
+
+import java.util.List;
 
 public class MainEnderecoSave {
 
@@ -13,20 +18,34 @@ public class MainEnderecoSave {
 
             AbstractDAOImpl.initialize("daw");
 
-            EnderecoDAO dao = new EnderecoDAOImpl();
+            EnderecoDAO enderecoDAO = new EnderecoDAOImpl();
+            ClienteDAO clienteDAO = new ClienteDAOImpl();
+
+            List<Cliente> clientes = clienteDAO.findAll();
+
+            System.out.println("Clientes no banco: " + clientes.size());
+
+            Cliente cliente = clientes.isEmpty() ? null : clientes.get(0);
+
+            System.out.println("ID do Cliente encontrado: " + (cliente != null ? cliente.getId() : "NULL"));
+
+            if (cliente == null) {
+                System.out.println("❌ Não há clientes no banco! Execute MainClienteSave primeiro.");
+                return;
+            }
 
             Endereco endereco = new Endereco();
-
             endereco.setRua("Rua das Flores");
             endereco.setNumero("123");
             endereco.setComplemento("Apto 101");
             endereco.setCep("58000000");
             endereco.setCidade("João Pessoa");
             endereco.setEstado("PB");
+            endereco.setCliente(cliente);
 
-            dao.save(endereco);
+            enderecoDAO.save(endereco);
 
-            System.out.println("Endereço salvo com sucesso!");
+            System.out.println("✅ Endereço salvo com sucesso!");
 
         } finally {
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainEntregaSave.java
@@ -1,12 +1,15 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.EntregaDAO;
+import br.edu.ifpb.es.daw.dao.PedidoDAO;
 import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.EntregaDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
 import br.edu.ifpb.es.daw.entities.Entrega;
+import br.edu.ifpb.es.daw.entities.Pedido;
 import br.edu.ifpb.es.daw.entities.StatusEntrega;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public class MainEntregaSave {
 
@@ -16,22 +19,31 @@ public class MainEntregaSave {
 
             AbstractDAOImpl.initialize("daw");
 
-            EntregaDAO dao = new EntregaDAOImpl();
+            EntregaDAO entregaDAO = new EntregaDAOImpl();
+            PedidoDAO pedidoDAO = new PedidoDAOImpl();
+
+            List<Pedido> pedidos = pedidoDAO.findAll();
+
+            System.out.println("Pedidos no banco: " + pedidos.size());
+
+            Pedido pedido = pedidos.isEmpty() ? null : pedidos.get(0);
+
+            System.out.println("ID do Pedido encontrado: " + (pedido != null ? pedido.getId() : "NULL"));
+
+            if (pedido == null) {
+                System.out.println("❌ Não há pedidos no banco! Execute MainPedidoSave primeiro.");
+                return;
+            }
 
             Entrega entrega = new Entrega();
-
             entrega.setTransportadora("Correios");
-
             entrega.setCodigoRastreamento("BR" + System.nanoTime());
-
             entrega.setStatusEntrega(StatusEntrega.SAIU_PARA_ENTREGA);
+            entrega.setPedido(pedido);
 
-            entrega.setDataEnvio(LocalDateTime.now());
-            entrega.setDataEntregaPrevista(LocalDateTime.now().plusDays(7));
+            entregaDAO.save(entrega);
 
-            dao.save(entrega);
-
-            System.out.println("Entrega salva com sucesso!");
+            System.out.println("✅ Entrega salva com sucesso!");
 
         } finally {
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemCarrinhoSave.java
@@ -30,31 +30,35 @@ public class MainItemCarrinhoSave {
             List<Carrinho> carrinhos = carrinhoDAO.findAll();
             List<Produto> produtos = produtoDAO.findAll();
 
-            System.out.println("Carrinhos no banco: " + carrinhos.size());
-            System.out.println("Produtos no banco: " + produtos.size());
-
             Carrinho carrinho = carrinhos.isEmpty() ? null : carrinhos.get(0);
             Produto produto = produtos.isEmpty() ? null : produtos.get(0);
-
-            System.out.println("ID do Carrinho encontrado: " + (carrinho != null ? carrinho.getId() : "NULL"));
-            System.out.println("ID do Produto encontrado: " + (produto != null ? produto.getId() : "NULL"));
 
             if (carrinho == null || produto == null) {
                 System.out.println("❌ Não há carrinhos ou produtos no banco!");
                 return;
             }
 
-            // Monta a chave composta
-            ItemCarrinhoId itemCarrinhoId = new ItemCarrinhoId();
-            itemCarrinhoId.setCarrinhoId(carrinho.getId());
-            itemCarrinhoId.setProdutoId(produto.getId());
+            System.out.println("ID do Carrinho encontrado: " + carrinho.getId());
+            System.out.println("ID do Produto encontrado: " + produto.getId());
+
+            // Verifica se o item já existe no carrinho
+            ItemCarrinho existente = itemCarrinhoDAO.findByCarrinhoAndProduto(carrinho.getId(), produto.getId());
+
+            if (existente != null) {
+                existente.setQuantidade(existente.getQuantidade() + 1);
+                itemCarrinhoDAO.update(existente);
+                System.out.println("⚠️ Item já existia no carrinho. Quantidade atualizada para: " + existente.getQuantidade());
+                return;
+            }
+
+            ItemCarrinhoId itemCarrinhoId = new ItemCarrinhoId(carrinho.getId(), produto.getId());
 
             ItemCarrinho itemCarrinho = new ItemCarrinho();
             itemCarrinho.setId(itemCarrinhoId);
             itemCarrinho.setCarrinho(carrinho);
             itemCarrinho.setProduto(produto);
             itemCarrinho.setPrecoUnitario(BigDecimal.valueOf(100.25));
-            itemCarrinho.setQuantidade(50);
+            itemCarrinho.setQuantidade(1);
 
             itemCarrinhoDAO.save(itemCarrinho);
 

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainItemPedidoSave.java
@@ -44,10 +44,18 @@ public class MainItemPedidoSave {
                 return;
             }
 
+            // Verifica se o item já existe no pedido
+            ItemPedido existente = itemPedidoDAO.findByPedidoAndProduto(pedido.getId(), produto.getId());
+
+            if (existente != null) {
+                existente.setQuantidade(existente.getQuantidade() + 1);
+                itemPedidoDAO.update(existente);
+                System.out.println("⚠️ Item já existia no pedido. Quantidade atualizada para: " + existente.getQuantidade());
+                return;
+            }
+
             // Monta a chave composta
-            ItemPedidoId itemPedidoId = new ItemPedidoId();
-            itemPedidoId.setIdPedido(pedido.getId());
-            itemPedidoId.setIdProduto(produto.getId());
+            ItemPedidoId itemPedidoId = new ItemPedidoId(pedido.getId(), produto.getId());
 
             ItemPedido itemPedido = new ItemPedido();
             itemPedido.setId(itemPedidoId);

--- a/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoSave.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/MainPagamentoSave.java
@@ -1,13 +1,17 @@
 package br.edu.ifpb.es.daw.main;
 
 import br.edu.ifpb.es.daw.dao.PagamentoDAO;
+import br.edu.ifpb.es.daw.dao.PedidoDAO;
 import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
 import br.edu.ifpb.es.daw.dao.impl.PagamentoDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
 import br.edu.ifpb.es.daw.entities.MetodoPagamento;
 import br.edu.ifpb.es.daw.entities.Pagamento;
+import br.edu.ifpb.es.daw.entities.Pedido;
 import br.edu.ifpb.es.daw.entities.StatusPagamento;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public class MainPagamentoSave {
 
@@ -17,17 +21,31 @@ public class MainPagamentoSave {
 
             AbstractDAOImpl.initialize("daw");
 
-            PagamentoDAO dao = new PagamentoDAOImpl();
+            PagamentoDAO pagamentoDAO = new PagamentoDAOImpl();
+            PedidoDAO pedidoDAO = new PedidoDAOImpl();
+
+            List<Pedido> pedidos = pedidoDAO.findAll();
+
+            System.out.println("Pedidos no banco: " + pedidos.size());
+
+            Pedido pedido = pedidos.isEmpty() ? null : pedidos.get(0);
+
+            System.out.println("ID do Pedido encontrado: " + (pedido != null ? pedido.getId() : "NULL"));
+
+            if (pedido == null) {
+                System.out.println("❌ Não há pedidos no banco! Execute MainPedidoSave primeiro.");
+                return;
+            }
 
             Pagamento pagamento = new Pagamento();
-
             pagamento.setMetodo(MetodoPagamento.PIX);
             pagamento.setStatus(StatusPagamento.APROVADO);
             pagamento.setValorPago(new BigDecimal("250.00"));
+            pagamento.setPedido(pedido);
 
-            dao.save(pagamento);
+            pagamentoDAO.save(pagamento);
 
-            System.out.println("Pagamento salvo com sucesso!");
+            System.out.println("✅ Pagamento salvo com sucesso!");
 
         } finally {
 


### PR DESCRIPTION
## Descrição

### Contexto
Durante a análise do projeto, foram identificados problemas em entidades, interfaces DAO e classes `Main` que impediam o correto funcionamento da persistência de dados via JPA/Hibernate.

---

### Alterações realizadas

#### Entidades
- **`Pedido.java`** — adicionado campo `cupom` com `@ManyToOne` (nullable), completando o relacionamento bidirecional com `Cupom` e corrigindo o `AnnotationException` causado pelo `mappedBy = "cupom"` que não encontrava o campo no lado proprietário
- **`ItemPedidoId.java`** — corrigidos os setters `setIdPedido` e `setIdProduto` que estavam com o corpo vazio, impedindo a atribuição dos IDs da chave composta

#### Interfaces e implementações DAO
- **`ItemCarrinhoDAO.java`** / **`ItemCarrinhoDAOImpl.java`** — adicionado método `findByCarrinhoAndProduto(Long carrinhoId, Long produtoId)` para busca por chave composta `@EmbeddedId`, já que o `findById` herdado espera `Long`
- **`ItemPedidoDAO.java`** / **`ItemPedidoDAOImpl.java`** — adicionado método `findByPedidoAndProduto(Long pedidoId, Long produtoId)` pelo mesmo motivo

#### Classes Main
| Classe | Problema | Correção |
|---|---|---|
| `MainDevolucaoSave` | Salvava `Devolucao` sem vincular `Pedido` | Busca pedido existente e vincula antes de salvar |
| `MainPagamentoSave` | Salvava `Pagamento` sem vincular `Pedido` | Busca pedido existente e vincula antes de salvar |
| `MainEntregaSave` | Salvava `Entrega` sem vincular `Pedido` | Busca pedido existente e vincula antes de salvar |
| `MainEnderecoSave` | Salvava `Endereco` sem vincular `Cliente` | Busca cliente existente e vincula antes de salvar |
| `MainCarrinhoSave` | Violava constraint única ao tentar criar segundo carrinho para o mesmo cliente | Verifica se cliente já possui carrinho antes de inserir |
| `MainItemCarrinhoSave` | Violava PK composta ao tentar inserir par `(carrinho, produto)` já existente | Verifica existência e atualiza quantidade se já existir |
| `MainItemPedidoSave` | Violava PK composta ao tentar inserir par `(pedido, produto)` já existente | Verifica existência e atualiza quantidade se já existir |

---

### Ordem de execução recomendada dos Mains
MainVendedorSave → MainCategoriaSave → MainClienteSave → MainCupomSave
→ MainProdutoSave → MainCarrinhoSave → MainPedidoSave
→ MainEnderecoSave → MainItemCarrinhoSave → MainItemPedidoSave
→ MainAvaliacaoSave → MainPagamentoSave → MainEntregaSave → MainDevolucaoSave

---

### Observação sobre os `DeleteAll`
Os `MainXDeleteAll` funcionam corretamente no código, porém devem ser executados na **ordem inversa** da listada acima para evitar violações de chave estrangeira no banco.