### PR TITLE
feat: Implementação das Consultas JPQL 2.1 a 2.5

### DIFF
--- a/src/main/java/br/edu/ifpb/es/daw/dao/AvaliacaoDAO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/AvaliacaoDAO.java
@@ -1,6 +1,17 @@
 package br.edu.ifpb.es.daw.dao;
 
 import br.edu.ifpb.es.daw.entities.Avaliacao;
+import br.edu.ifpb.es.daw.entities.Produto;
 
 public interface AvaliacaoDAO extends DAO<Avaliacao> {
+
+    /**
+     * 2.4 - Consulta que faz uso de função de agregação (AVG).
+     * Retorna a média das notas de todas as avaliações do produto informado.
+     *
+     * @param produto entidade Produto cujas avaliações serão consideradas
+     * @return média das notas do produto, ou null se não houver avaliações
+     */
+    Double calcularMediaNotasPorProduto(Produto produto) throws PersistenciaDawException;
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/PedidoDAO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/PedidoDAO.java
@@ -1,6 +1,29 @@
 package br.edu.ifpb.es.daw.dao;
 
+import br.edu.ifpb.es.daw.entities.Cliente;
 import br.edu.ifpb.es.daw.entities.Pedido;
 
+import java.util.List;
+
 public interface PedidoDAO extends DAO<Pedido> {
+
+    /**
+     *
+     * 2.2 - Consulta parametrizada onde o parâmetro é uma entidade (Cliente).
+     * Retorna todos os pedidos associados ao cliente informado.
+     *
+     * @param cliente entidade Cliente a ser usada como parâmetro da consulta
+     * @return lista de pedidos do cliente
+     */
+    List<Pedido> findByCliente(Cliente cliente) throws PersistenciaDawException;
+
+    /**
+     * 2.5 - Consulta que faz FETCH de relacionamento LAZY (itens do pedido).
+     * Retorna o pedido com a lista de itens já carregada, evitando LazyInitializationException.
+     *
+     * @param id identificador do pedido
+     * @return pedido com itens carregados via JOIN FETCH
+     */
+    Pedido findByIdComItens(Long id) throws PersistenciaDawException;
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/ProdutoDAO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/ProdutoDAO.java
@@ -2,5 +2,28 @@ package br.edu.ifpb.es.daw.dao;
 
 import br.edu.ifpb.es.daw.entities.Produto;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 public interface ProdutoDAO extends DAO<Produto> {
+
+    /**
+     * 2.1 - Consulta parametrizada com um parâmetro de tipo primitivo/wrapper (String).
+     * Retorna todos os produtos cujo nome contenha o trecho informado.
+     *
+     * @param nome trecho do nome a ser buscado
+     * @return lista de produtos encontrados
+     */
+    List<Produto> findByNome(String nome) throws PersistenciaDawException;
+
+    /**
+     * 2.3 - Consulta parametrizada com dois parâmetros de tipos primitivos/wrappers (BigDecimal).
+     * Retorna todos os produtos com preço dentro da faixa informada.
+     *
+     * @param precoMin preço mínimo (inclusive)
+     * @param precoMax preço máximo (inclusive)
+     * @return lista de produtos encontrados
+     */
+    List<Produto> findByFaixaDePreco(BigDecimal precoMin, BigDecimal precoMax) throws PersistenciaDawException;
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/AvaliacaoDAOImpl.java
@@ -1,12 +1,31 @@
 package br.edu.ifpb.es.daw.dao.impl;
 
 import br.edu.ifpb.es.daw.dao.AvaliacaoDAO;
+import br.edu.ifpb.es.daw.dao.PersistenciaDawException;
 import br.edu.ifpb.es.daw.entities.Avaliacao;
+import br.edu.ifpb.es.daw.entities.Produto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.TypedQuery;
 
 public class AvaliacaoDAOImpl extends AbstractDAOImpl<Avaliacao> implements AvaliacaoDAO {
 
     public AvaliacaoDAOImpl() {
-
         super(Avaliacao.class);
     }
+
+    // 2.4 - Consulta que faz uso de função de agregação (AVG)
+    @Override
+    public Double calcularMediaNotasPorProduto(Produto produto) throws PersistenciaDawException {
+        try (EntityManager em = getEntityManager()) {
+            TypedQuery<Double> query = em.createQuery(
+                    "SELECT AVG(a.nota) FROM Avaliacao a WHERE a.produto = :produto", Double.class);
+            query.setParameter("produto", produto);
+            return query.getSingleResult();
+        } catch (PersistenceException pe) {
+            pe.printStackTrace();
+            throw new PersistenciaDawException("Ocorreu algum erro ao tentar calcular a média das notas do produto informado.", pe);
+        }
+    }
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/PedidoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/PedidoDAOImpl.java
@@ -1,11 +1,47 @@
 package br.edu.ifpb.es.daw.dao.impl;
 
+import br.edu.ifpb.es.daw.dao.PersistenciaDawException;
 import br.edu.ifpb.es.daw.dao.PedidoDAO;
+import br.edu.ifpb.es.daw.entities.Cliente;
 import br.edu.ifpb.es.daw.entities.Pedido;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.TypedQuery;
+
+import java.util.List;
 
 public class PedidoDAOImpl extends AbstractDAOImpl<Pedido> implements PedidoDAO {
 
     public PedidoDAOImpl() {
         super(Pedido.class);
     }
+
+    // 2.2 - Consulta parametrizada onde o parâmetro é uma entidade (Cliente)
+    @Override
+    public List<Pedido> findByCliente(Cliente cliente) throws PersistenciaDawException {
+        try (EntityManager em = getEntityManager()) {
+            TypedQuery<Pedido> query = em.createQuery(
+                    "SELECT p FROM Pedido p WHERE p.cliente = :cliente", Pedido.class);
+            query.setParameter("cliente", cliente);
+            return query.getResultList();
+        } catch (PersistenceException pe) {
+            pe.printStackTrace();
+            throw new PersistenciaDawException("Ocorreu algum erro ao tentar recuperar os pedidos do cliente informado.", pe);
+        }
+    }
+
+    // 2.5 - Consulta que faz FETCH de relacionamento LAZY (itens do pedido)
+    @Override
+    public Pedido findByIdComItens(Long id) throws PersistenciaDawException {
+        try (EntityManager em = getEntityManager()) {
+            TypedQuery<Pedido> query = em.createQuery(
+                    "SELECT DISTINCT p FROM Pedido p JOIN FETCH p.itens WHERE p.id = :id", Pedido.class);
+            query.setParameter("id", id);
+            return query.getSingleResult();
+        } catch (PersistenceException pe) {
+            pe.printStackTrace();
+            throw new PersistenciaDawException("Ocorreu algum erro ao tentar recuperar o pedido com seus itens pelo id.", pe);
+        }
+    }
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/dao/impl/ProdutoDAOImpl.java
+++ b/src/main/java/br/edu/ifpb/es/daw/dao/impl/ProdutoDAOImpl.java
@@ -1,11 +1,48 @@
 package br.edu.ifpb.es.daw.dao.impl;
 
+import br.edu.ifpb.es.daw.dao.PersistenciaDawException;
 import br.edu.ifpb.es.daw.dao.ProdutoDAO;
 import br.edu.ifpb.es.daw.entities.Produto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.TypedQuery;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 public class ProdutoDAOImpl extends AbstractDAOImpl<Produto> implements ProdutoDAO {
 
     public ProdutoDAOImpl() {
         super(Produto.class);
     }
+
+    // 2.1 - Consulta parametrizada com um parâmetro de tipo primitivo/wrapper (String)
+    @Override
+    public List<Produto> findByNome(String nome) throws PersistenciaDawException {
+        try (EntityManager em = getEntityManager()) {
+            TypedQuery<Produto> query = em.createQuery(
+                    "SELECT p FROM Produto p WHERE p.nome LIKE :nome", Produto.class);
+            query.setParameter("nome", "%" + nome + "%");
+            return query.getResultList();
+        } catch (PersistenceException pe) {
+            pe.printStackTrace();
+            throw new PersistenciaDawException("Ocorreu algum erro ao tentar recuperar produtos pelo nome.", pe);
+        }
+    }
+
+    // 2.3 - Consulta parametrizada com dois parâmetros de tipos primitivos/wrappers (BigDecimal)
+    @Override
+    public List<Produto> findByFaixaDePreco(BigDecimal precoMin, BigDecimal precoMax) throws PersistenciaDawException {
+        try (EntityManager em = getEntityManager()) {
+            TypedQuery<Produto> query = em.createQuery(
+                    "SELECT p FROM Produto p WHERE p.preco BETWEEN :precoMin AND :precoMax", Produto.class);
+            query.setParameter("precoMin", precoMin);
+            query.setParameter("precoMax", precoMax);
+            return query.getResultList();
+        } catch (PersistenceException pe) {
+            pe.printStackTrace();
+            throw new PersistenciaDawException("Ocorreu algum erro ao tentar recuperar produtos pela faixa de preço.", pe);
+        }
+    }
+
 }

--- a/src/main/java/br/edu/ifpb/es/daw/main/consultas/MainConsultas.java
+++ b/src/main/java/br/edu/ifpb/es/daw/main/consultas/MainConsultas.java
@@ -1,0 +1,125 @@
+package br.edu.ifpb.es.daw.main.consultas;
+
+import br.edu.ifpb.es.daw.dao.AvaliacaoDAO;
+import br.edu.ifpb.es.daw.dao.ClienteDAO;
+import br.edu.ifpb.es.daw.dao.PedidoDAO;
+import br.edu.ifpb.es.daw.dao.PersistenciaDawException;
+import br.edu.ifpb.es.daw.dao.ProdutoDAO;
+import br.edu.ifpb.es.daw.dao.impl.AbstractDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.AvaliacaoDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.ClienteDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.PedidoDAOImpl;
+import br.edu.ifpb.es.daw.dao.impl.ProdutoDAOImpl;
+import br.edu.ifpb.es.daw.entities.Cliente;
+import br.edu.ifpb.es.daw.entities.Pedido;
+import br.edu.ifpb.es.daw.entities.Produto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class MainConsultas {
+
+    public static void main(String[] args) throws PersistenciaDawException {
+
+        try {
+
+            AbstractDAOImpl.initialize("daw");
+
+            ProdutoDAO produtoDAO = new ProdutoDAOImpl();
+            PedidoDAO pedidoDAO = new PedidoDAOImpl();
+            AvaliacaoDAO avaliacaoDAO = new AvaliacaoDAOImpl();
+            ClienteDAO clienteDAO = new ClienteDAOImpl();
+
+            // ================================================================
+            // 2.1 - Consulta parametrizada com um parâmetro primitivo/wrapper
+            // Busca produtos cujo nome contenha o trecho informado (String)
+            // ================================================================
+            System.out.println("==============================");
+            System.out.println("=== Consulta 2.1 - findByNome(\"Notebook\") ===");
+            System.out.println("==============================");
+            List<Produto> porNome = produtoDAO.findByNome("Notebook");
+            if (porNome.isEmpty()) {
+                System.out.println("Nenhum produto encontrado.");
+            } else {
+                porNome.forEach(p -> System.out.println("  -> " + p));
+            }
+
+            // ================================================================
+            // 2.2 - Consulta parametrizada onde o parâmetro é uma entidade
+            // Busca todos os pedidos de um cliente passado como objeto JPA
+            // ================================================================
+            System.out.println("\n==============================");
+            System.out.println("=== Consulta 2.2 - findByCliente(cliente) ===");
+            System.out.println("==============================");
+            List<Cliente> clientes = clienteDAO.findAll();
+            if (clientes.isEmpty()) {
+                System.out.println("Nenhum cliente no banco. Execute o MainDataGenerator primeiro.");
+            } else {
+                Cliente cliente = clientes.get(0);
+                System.out.println("Buscando pedidos do cliente: " + cliente.getNome());
+                List<Pedido> porCliente = pedidoDAO.findByCliente(cliente);
+                if (porCliente.isEmpty()) {
+                    System.out.println("Nenhum pedido encontrado para esse cliente.");
+                } else {
+                    porCliente.forEach(p -> System.out.println("  -> " + p));
+                }
+            }
+
+            // ================================================================
+            // 2.3 - Consulta parametrizada com dois parâmetros primitivos/wrappers
+            // Busca produtos com preço entre dois valores BigDecimal
+            // ================================================================
+            System.out.println("\n==============================");
+            System.out.println("=== Consulta 2.3 - findByFaixaDePreco(100.00, 4000.00) ===");
+            System.out.println("==============================");
+            List<Produto> porFaixa = produtoDAO.findByFaixaDePreco(
+                    new BigDecimal("100.00"), new BigDecimal("4000.00"));
+            if (porFaixa.isEmpty()) {
+                System.out.println("Nenhum produto encontrado na faixa de preço informada.");
+            } else {
+                porFaixa.forEach(p -> System.out.println("  -> " + p));
+            }
+
+            // ================================================================
+            // 2.4 - Consulta com função de agregação (AVG)
+            // Calcula a média das notas das avaliações do primeiro produto encontrado
+            // ================================================================
+            System.out.println("\n==============================");
+            System.out.println("=== Consulta 2.4 - calcularMediaNotasPorProduto(produto) ===");
+            System.out.println("==============================");
+            List<Produto> produtos = produtoDAO.findAll();
+            if (produtos.isEmpty()) {
+                System.out.println("Nenhum produto no banco. Execute o MainDataGenerator primeiro.");
+            } else {
+                Produto produto = produtos.get(0);
+                Double media = avaliacaoDAO.calcularMediaNotasPorProduto(produto);
+                System.out.println("  Média das notas do produto \"" + produto.getNome() + "\": " + media);
+            }
+
+            // ================================================================
+            // 2.5 - Consulta com FETCH de relacionamento LAZY
+            // Busca o primeiro pedido já com seus itens carregados via JOIN FETCH
+            // ================================================================
+            System.out.println("\n==============================");
+            System.out.println("=== Consulta 2.5 - findByIdComItens(id) ===");
+            System.out.println("==============================");
+            List<Pedido> pedidos = pedidoDAO.findAll();
+            if (pedidos.isEmpty()) {
+                System.out.println("Nenhum pedido no banco. Execute o MainDataGenerator primeiro.");
+            } else {
+                Long idPedido = pedidos.get(0).getId();
+                Pedido pedidoComItens = pedidoDAO.findByIdComItens(idPedido);
+                System.out.println("  Pedido: " + pedidoComItens);
+                System.out.println("  Itens carregados via JOIN FETCH:");
+                pedidoComItens.getItens().forEach(i -> System.out.println("    -> " + i));
+            }
+
+        } finally {
+
+            AbstractDAOImpl.closeFactory();
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
## O que foi feito

Implementação das 5 consultas JPQL exigidas na atividade 03 da disciplina DAW2,
cobrindo parâmetros primitivos/wrappers, parâmetro entidade, dois parâmetros,
função de agregação e JOIN FETCH em relacionamento LAZY.

## Consultas implementadas

- `ProdutoDAO` / `ProdutoDAOImpl` → `findByNome(String nome)` (2.1)
- `PedidoDAO` / `PedidoDAOImpl` → `findByCliente(Cliente cliente)` (2.2)
- `ProdutoDAO` / `ProdutoDAOImpl` → `findByFaixaDePreco(BigDecimal precoMin, BigDecimal precoMax)` (2.3)
- `AvaliacaoDAO` / `AvaliacaoDAOImpl` → `calcularMediaNotasPorProduto(Produto produto)` (2.4)
- `PedidoDAO` / `PedidoDAOImpl` → `findByIdComItens(Long id)` (2.5)

## Teste

Todas as consultas foram exercitadas e validadas via `MainConsultas`,
com as queries SQL geradas pelo Hibernate exibidas no console.

## Issues fechadas


Closes #30 
Closes #31 
Closes #32 
Closes #33 
Closes #34 