### PR TITLE
Feature:  Implementação de Autenticação JWT, Segurança e Seed de Dados

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,24 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/br/edu/ifpb/es/daw/config/SecurityConfiguration.java
+++ b/src/main/java/br/edu/ifpb/es/daw/config/SecurityConfiguration.java
@@ -1,33 +1,76 @@
 package br.edu.ifpb.es.daw.config;
 
+import br.edu.ifpb.es.daw.rest.filter.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-/**
- * Configuração TEMPORÁRIA.
- *
- * Libera todos os endpoints enquanto a Issue 2 (JWT) e a Issue 3 (SecurityConfiguration final
- * com JwtAuthenticationFilter + UserDetailsService) ainda não estão prontas.
- *
- * Quando a Issue 3 estiver implementada, este arquivo deve ser SUBSTITUÍDO pela
- * SecurityConfiguration definitiva (não deixar as duas coexistirem).
- */
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
 public class SecurityConfiguration {
+
+    @Autowired private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @Autowired private UserDetailsService userDetailsService;
+    @Autowired private PasswordEncoder passwordEncoder;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
+                        .requestMatchers("/auth/login", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/clientes", "/vendedores").permitAll()
+                        .requestMatchers("/seed/**").hasAuthority("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, err) -> {
+                            res.setStatus(401);
+                            res.getWriter().write("Nao autenticado");
+                        })
+                        .accessDeniedHandler((req, res, err) -> {
+                            res.setStatus(403);
+                            res.getWriter().write("Sem permissao");
+                        })
+                )
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        // CORREÇÃO FINAL: Passando o argumento exigido pelo erro do seu Maven
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder);
+        return authProvider;
+    }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/config/SpringDocConfiguration.java
+++ b/src/main/java/br/edu/ifpb/es/daw/config/SpringDocConfiguration.java
@@ -1,10 +1,13 @@
 package br.edu.ifpb.es.daw.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SpringDocConfiguration {
@@ -24,6 +27,14 @@ public class SpringDocConfiguration {
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("IFPB - Instituto Federal da Paraíba")
-                                .url("https://www.ifpb.edu.br")));
+                                .url("https://www.ifpb.edu.br")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("Insira o token JWT obtido em POST /auth/login")));
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/config/StartupListener.java
+++ b/src/main/java/br/edu/ifpb/es/daw/config/StartupListener.java
@@ -1,17 +1,45 @@
 package br.edu.ifpb.es.daw.config;
 
+import br.edu.ifpb.es.daw.model.Admin;
+import br.edu.ifpb.es.daw.model.enums.Role;
+import br.edu.ifpb.es.daw.repository.AdminRepository;
+import br.edu.ifpb.es.daw.repository.UsuarioRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StartupListener {
 
+    private static final String ADMIN_EMAIL = "admin@marketplace.com";
+    private static final String ADMIN_SENHA = "admin123";
+
+    @Autowired private UsuarioRepository usuarioRepository;
+    @Autowired private AdminRepository adminRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
     @EventListener(ApplicationReadyEvent.class)
     public void onStartup() {
+        criarAdminPadraoSeNaoExistir();
+
         System.out.println("\n--------------------------------------------------");
         System.out.println("✅ Aplicação iniciada com sucesso!");
         System.out.println("📄 Swagger disponível em: http://localhost:8080/swagger-ui/index.html");
+        System.out.println("👤 Admin padrão: " + ADMIN_EMAIL + " / " + ADMIN_SENHA);
         System.out.println("--------------------------------------------------\n");
+    }
+
+    public void criarAdminPadraoSeNaoExistir() {
+        if (usuarioRepository.findByEmail(ADMIN_EMAIL).isEmpty()) {
+            Admin admin = new Admin();
+            admin.setNome("Administrador");
+            admin.setEmail(ADMIN_EMAIL);
+            admin.setSenha(passwordEncoder.encode(ADMIN_SENHA));
+            admin.setRole(Role.ADMIN);
+            adminRepository.save(admin);
+            System.out.println("🔐 Admin padrão criado.");
+        }
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/rest/AdminRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/AdminRestController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,23 +22,27 @@ public class AdminRestController implements AdminRestControllerApi {
     @Autowired private AdminService service;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Page<AdminResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<AdminResponseDTO> adicionar(@RequestBody @Valid AdminRequestDTO dto) {
         Admin novo = mapper.from(dto);
         return new ResponseEntity<>(mapper.from(service.criar(novo, dto.getSenha())), HttpStatus.CREATED);
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<AdminResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<AdminResponseDTO> atualizar(@PathVariable Long id, @RequestBody @Valid AdminRequestDTO dto) {
         Admin obj = validarExiste(id);
         obj.setEmail(dto.getEmail());
@@ -45,6 +50,7 @@ public class AdminRestController implements AdminRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/AuthController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/AuthController.java
@@ -1,0 +1,47 @@
+package br.edu.ifpb.es.daw.rest;
+
+import br.edu.ifpb.es.daw.exception.EntidadeNaoEncontradaException;
+import br.edu.ifpb.es.daw.model.Usuario;
+import br.edu.ifpb.es.daw.repository.UsuarioRepository;
+import br.edu.ifpb.es.daw.rest.dto.request.AuthRequestDTO;
+import br.edu.ifpb.es.daw.rest.dto.response.AuthResponseDTO;
+import br.edu.ifpb.es.daw.service.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "Autenticação")
+public class AuthController {
+
+    @Autowired private AuthenticationManager authenticationManager;
+    @Autowired private JwtService jwtService;
+    @Autowired private UsuarioRepository usuarioRepository;
+
+    @PostMapping("/login")
+    @Operation(summary = "Realizar login e obter token JWT")
+    public ResponseEntity<AuthResponseDTO> login(@RequestBody @Valid AuthRequestDTO dto) {
+
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(dto.email(), dto.senha())
+        );
+
+        Usuario usuario = usuarioRepository.findByEmail(dto.email())
+                .orElseThrow(() -> new EntidadeNaoEncontradaException("Usuario", "email", dto.email()));
+
+        String token = jwtService.generateToken(usuario.getEmail(), usuario.getRole());
+
+        return ResponseEntity.ok(new AuthResponseDTO(token, usuario.getRole().name(), usuario.getEmail()));
+    }
+}

--- a/src/main/java/br/edu/ifpb/es/daw/rest/AvaliacaoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/AvaliacaoRestController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,12 +28,14 @@ public class AvaliacaoRestController implements AvaliacaoRestControllerApi {
     @Autowired private ProdutoService produtoService;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<Page<AvaliacaoResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<AvaliacaoResponseDTO> adicionar(@RequestBody @Valid AvaliacaoRequestDTO dto) {
         Avaliacao obj = mapper.from(dto);
         Cliente cliente = clienteService.buscarPorId(dto.getIdCliente())
@@ -51,6 +54,7 @@ public class AvaliacaoRestController implements AvaliacaoRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(service.buscarPorId(id)
                 .orElseThrow(() -> new EntidadeNaoEncontradaException("Avaliacao", id)));

--- a/src/main/java/br/edu/ifpb/es/daw/rest/CarrinhoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/CarrinhoRestController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,6 +24,7 @@ public class CarrinhoRestController implements CarrinhoRestControllerApi {
     @Autowired private ClienteService clienteService;
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<CarrinhoResponseDTO> adicionar(@RequestBody @Valid CarrinhoRequestDTO dto) {
         Carrinho obj = mapper.from(dto);
         Cliente cliente = clienteService.buscarPorId(dto.getIdCliente())
@@ -38,6 +40,7 @@ public class CarrinhoRestController implements CarrinhoRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}/limpar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<CarrinhoResponseDTO> limpar(@PathVariable Long id) {
         Carrinho obj = service.buscarPorId(id)
                 .orElseThrow(() -> new EntidadeNaoEncontradaException("Carrinho", id));

--- a/src/main/java/br/edu/ifpb/es/daw/rest/CategoriaRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/CategoriaRestController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,22 +22,26 @@ public class CategoriaRestController implements CategoriaRestControllerApi {
     @Autowired private CategoriaService service;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<Page<CategoriaResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'VENDEDOR')")
     public ResponseEntity<CategoriaResponseDTO> adicionar(@RequestBody @Valid CategoriaRequestDTO dto) {
         return new ResponseEntity<>(mapper.from(service.criar(mapper.from(dto))), HttpStatus.CREATED);
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<CategoriaResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'VENDEDOR')")
     public ResponseEntity<CategoriaResponseDTO> atualizar(@PathVariable Long id, @RequestBody @Valid CategoriaRequestDTO dto) {
         Categoria obj = validarExiste(id);
         Categoria atualizado = mapper.from(dto);
@@ -45,6 +50,7 @@ public class CategoriaRestController implements CategoriaRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/ClienteRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/ClienteRestController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,12 +22,13 @@ public class ClienteRestController implements ClienteRestControllerApi {
     @Autowired private ClienteService service;
 
     @Override @GetMapping
-    public ResponseEntity<Page<ClienteResponseDTO>> listar(
-            @RequestParam(defaultValue = "0") int page) {
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
+    public ResponseEntity<Page<ClienteResponseDTO>> listar(@RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @GetMapping("/buscar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<Page<ClienteResponseDTO>> buscar(
             @RequestParam(required = false) String nome,
             @RequestParam(required = false) String email,
@@ -36,18 +38,18 @@ public class ClienteRestController implements ClienteRestControllerApi {
 
     @Override @PostMapping
     public ResponseEntity<ClienteResponseDTO> adicionar(@RequestBody @Valid ClienteRequestDTO dto) {
-        Cliente obj = service.criar(mapper.from(dto));
-        return new ResponseEntity<>(mapper.from(obj), HttpStatus.CREATED);
+        return new ResponseEntity<>(mapper.from(service.criar(mapper.from(dto))), HttpStatus.CREATED);
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<ClienteResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}")
-    public ResponseEntity<ClienteResponseDTO> atualizar(@PathVariable Long id,
-                                                        @RequestBody @Valid ClienteRequestDTO dto) {
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
+    public ResponseEntity<ClienteResponseDTO> atualizar(@PathVariable Long id, @RequestBody @Valid ClienteRequestDTO dto) {
         Cliente obj = validarExiste(id);
         obj.setNome(dto.getNome());
         obj.setEmail(dto.getEmail());
@@ -56,13 +58,13 @@ public class ClienteRestController implements ClienteRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();
     }
 
     private Cliente validarExiste(Long id) {
-        return service.buscarPorId(id)
-                .orElseThrow(() -> new EntidadeNaoEncontradaException("Cliente", id));
+        return service.buscarPorId(id).orElseThrow(() -> new EntidadeNaoEncontradaException("Cliente", id));
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/rest/CupomRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/CupomRestController.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,12 +23,14 @@ public class CupomRestController implements CupomRestControllerApi {
     @Autowired private CupomService service;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Page<CupomResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @GetMapping("/buscar")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Page<CupomResponseDTO>> buscar(
             @RequestParam(required = false) String codigo,
             @RequestParam(required = false) StatusCupom status,
@@ -36,16 +39,19 @@ public class CupomRestController implements CupomRestControllerApi {
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<CupomResponseDTO> adicionar(@RequestBody @Valid CupomRequestDTO dto) {
         return new ResponseEntity<>(mapper.from(service.criar(mapper.from(dto))), HttpStatus.CREATED);
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<CupomResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<CupomResponseDTO> atualizar(@PathVariable Long id,
                                                       @RequestBody @Valid CupomRequestDTO dto) {
         Cupom obj = validarExiste(id);
@@ -55,6 +61,7 @@ public class CupomRestController implements CupomRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/DevolucaoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/DevolucaoRestController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,6 +30,7 @@ public class DevolucaoRestController implements DevolucaoRestControllerApi {
 
     @Override
     @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<DevolucaoResponseDTO> adicionar(@RequestBody @Valid DevolucaoRequestDTO dto) {
         Devolucao obj = mapper.from(dto);
         Pedido pedido = pedidoService.buscarPorId(dto.getIdPedido())
@@ -45,12 +47,14 @@ public class DevolucaoRestController implements DevolucaoRestControllerApi {
 
     @Override
     @PatchMapping("/{id}/aprovar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<DevolucaoResponseDTO> aprovar(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(service.aprovar(validarExiste(id))));
     }
 
     @Override
     @PatchMapping("/{id}/rejeitar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<DevolucaoResponseDTO> rejeitar(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(service.rejeitar(validarExiste(id))));
     }

--- a/src/main/java/br/edu/ifpb/es/daw/rest/EnderecoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/EnderecoRestController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,6 +28,7 @@ public class EnderecoRestController implements EnderecoRestControllerApi {
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<EnderecoResponseDTO> adicionar(@RequestBody @Valid EnderecoRequestDTO dto) {
         return new ResponseEntity<>(mapper.from(service.criar(mapper.from(dto))), HttpStatus.CREATED);
     }
@@ -37,6 +39,7 @@ public class EnderecoRestController implements EnderecoRestControllerApi {
     }
 
     @Override @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<EnderecoResponseDTO> atualizar(@PathVariable Long id, @RequestBody @Valid EnderecoRequestDTO dto) {
         Endereco obj = validarExiste(id);
         Endereco atualizado = mapper.from(dto);
@@ -45,6 +48,7 @@ public class EnderecoRestController implements EnderecoRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/ItemCarrinhoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/ItemCarrinhoRestController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,12 +29,14 @@ public class ItemCarrinhoRestController implements ItemCarrinhoRestControllerApi
     @Autowired private ProdutoService produtoService;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<Page<ItemCarrinhoResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<ItemCarrinhoResponseDTO> adicionar(@RequestBody @Valid ItemCarrinhoRequestDTO dto) {
         ItemCarrinho obj = mapper.from(dto);
         Carrinho carrinho = carrinhoService.buscarPorId(dto.getIdCarrinho())

--- a/src/main/java/br/edu/ifpb/es/daw/rest/ItemPedidoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/ItemPedidoRestController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,12 +29,14 @@ public class ItemPedidoRestController implements ItemPedidoRestControllerApi {
     @Autowired private ProdutoService produtoService;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<Page<ItemPedidoResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<ItemPedidoResponseDTO> adicionar(@RequestBody @Valid ItemPedidoRequestDTO dto) {
         ItemPedido obj = mapper.from(dto);
         Pedido pedido = pedidoService.buscarPorId(dto.getIdPedido())

--- a/src/main/java/br/edu/ifpb/es/daw/rest/PagamentoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/PagamentoRestController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,6 +24,7 @@ public class PagamentoRestController implements PagamentoRestControllerApi {
     @Autowired private PedidoService pedidoService;
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<PagamentoResponseDTO> adicionar(@RequestBody @Valid PagamentoRequestDTO dto) {
         Pagamento obj = mapper.from(dto);
         Pedido pedido = pedidoService.buscarPorId(dto.getIdPedido())
@@ -37,6 +39,7 @@ public class PagamentoRestController implements PagamentoRestControllerApi {
     }
 
     @Override @PatchMapping("/{id}/confirmar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<PagamentoResponseDTO> confirmar(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(service.confirmar(validarExiste(id))));
     }

--- a/src/main/java/br/edu/ifpb/es/daw/rest/PedidoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/PedidoRestController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,12 +28,14 @@ public class PedidoRestController implements PedidoRestControllerApi {
     @Autowired private CupomService cupomService;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<Page<PedidoResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<PedidoResponseDTO> adicionar(@RequestBody @Valid PedidoRequestDTO dto) {
         Pedido obj = mapper.from(dto);
         Cliente cliente = clienteService.buscarPorId(dto.getIdCliente())
@@ -47,21 +50,25 @@ public class PedidoRestController implements PedidoRestControllerApi {
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<PedidoResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}/fechar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<PedidoResponseDTO> fechar(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(service.fechar(validarExiste(id))));
     }
 
     @Override @PatchMapping("/{id}/cancelar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
     public ResponseEntity<PedidoResponseDTO> cancelar(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(service.cancelar(validarExiste(id))));
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/ProdutoRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/ProdutoRestController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -29,12 +30,14 @@ public class ProdutoRestController implements ProdutoRestControllerApi {
     @Autowired private VendedorService vendedorService;
 
     @Override @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<Page<ProdutoResponseDTO>> listar(
             @RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
     @Override @GetMapping("/buscar")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<Page<ProdutoResponseDTO>> buscar(
             @RequestParam(required = false) String nome,
             @RequestParam(required = false) Long idCategoria,
@@ -47,6 +50,7 @@ public class ProdutoRestController implements ProdutoRestControllerApi {
     }
 
     @Override @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<ProdutoResponseDTO> adicionar(@RequestBody @Valid ProdutoRequestDTO dto) {
         Produto obj = mapper.from(dto);
         Categoria categoria = categoriaService.buscarPorId(dto.getIdCategoria())
@@ -59,11 +63,13 @@ public class ProdutoRestController implements ProdutoRestControllerApi {
     }
 
     @Override @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR', 'CLIENTE')")
     public ResponseEntity<ProdutoResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
     @Override @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<ProdutoResponseDTO> atualizar(@PathVariable Long id,
                                                         @RequestBody @Valid ProdutoRequestDTO dto) {
         Produto obj = validarExiste(id);
@@ -80,6 +86,7 @@ public class ProdutoRestController implements ProdutoRestControllerApi {
     }
 
     @Override @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/VendedorRestController.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/VendedorRestController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,23 +21,30 @@ public class VendedorRestController implements VendedorRestControllerApi {
     @Autowired private VendedorMapper mapper;
     @Autowired private VendedorService service;
 
-    @Override @GetMapping
-    public ResponseEntity<Page<VendedorResponseDTO>> listar(
-            @RequestParam(defaultValue = "0") int page) {
+    @Override
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE')")
+    public ResponseEntity<Page<VendedorResponseDTO>> listar(@RequestParam(defaultValue = "0") int page) {
         return ResponseEntity.ok(service.recuperarTodos(page).map(mapper::from));
     }
 
-    @Override @PostMapping
+    @Override
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<VendedorResponseDTO> adicionar(@RequestBody @Valid VendedorRequestDTO dto) {
         return new ResponseEntity<>(mapper.from(service.criar(mapper.from(dto))), HttpStatus.CREATED);
     }
 
-    @Override @GetMapping("/{id}")
+    @Override
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'CLIENTE', 'VENDEDOR')")
     public ResponseEntity<VendedorResponseDTO> recuperarPor(@PathVariable Long id) {
         return ResponseEntity.ok(mapper.from(validarExiste(id)));
     }
 
-    @Override @PatchMapping("/{id}")
+    @Override
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'VENDEDOR')")
     public ResponseEntity<VendedorResponseDTO> atualizar(@PathVariable Long id, @RequestBody @Valid VendedorRequestDTO dto) {
         Vendedor obj = validarExiste(id);
         Vendedor atualizado = mapper.from(dto);
@@ -44,7 +52,9 @@ public class VendedorRestController implements VendedorRestControllerApi {
         return ResponseEntity.ok(mapper.from(service.atualizar(atualizado)));
     }
 
-    @Override @DeleteMapping("/{id}")
+    @Override
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     public ResponseEntity<Void> remover(@PathVariable Long id) {
         service.remover(validarExiste(id));
         return ResponseEntity.noContent().build();

--- a/src/main/java/br/edu/ifpb/es/daw/rest/advice/GlobalExceptionHandler.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/advice/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,7 +27,30 @@ import java.util.Map;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     enum ErrorType {
-        ERRO_INESPERADO, REQUISICAO_INVALIDA, ESTADO_INVALIDO, ERRO_DE_VALIDACAO, ENTIDADE_NAO_ENCONTRADA
+        ERRO_INESPERADO, REQUISICAO_INVALIDA, ESTADO_INVALIDO, ERRO_DE_VALIDACAO,
+        ENTIDADE_NAO_ENCONTRADA, NAO_AUTENTICADO, ACESSO_NEGADO
+    }
+
+    /**
+     * 401 - Sem autenticação: token ausente, inválido ou expirado.
+     */
+    @ExceptionHandler(AuthenticationException.class)
+    public ProblemDetail handleAuthenticationException(AuthenticationException ex) {
+        ProblemDetail pd = buildProblemDetail(ex, HttpStatus.UNAUTHORIZED, ErrorType.NAO_AUTENTICADO);
+        pd.setDetail("Você precisa estar autenticado para acessar este recurso. " +
+                "Faça login em /auth/login e envie o token no header: Authorization: Bearer <token>");
+        return pd;
+    }
+
+    /**
+     * 403 - Autenticado, mas sem permissão para o recurso.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ProblemDetail handleAccessDeniedException(AccessDeniedException ex) {
+        ProblemDetail pd = buildProblemDetail(ex, HttpStatus.FORBIDDEN, ErrorType.ACESSO_NEGADO);
+        pd.setDetail("Você não tem permissão para realizar esta operação. " +
+                "Verifique se sua conta possui o perfil necessário (CLIENTE, VENDEDOR ou ADMIN).");
+        return pd;
     }
 
     @ExceptionHandler(Exception.class)
@@ -69,14 +94,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private ProblemDetail buildProblemDetail(Exception ex, HttpStatus status, ErrorType type) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, ex.getLocalizedMessage());
         problemDetail.setType(URI.create(type.name()));
-        problemDetail.setProperty("trace", stackTraceToString(ex));
         problemDetail.setProperty("timestamp", LocalDateTime.now());
         return problemDetail;
-    }
-
-    private String stackTraceToString(Exception ex) {
-        StringWriter errors = new StringWriter();
-        ex.printStackTrace(new PrintWriter(errors));
-        return errors.toString();
     }
 }

--- a/src/main/java/br/edu/ifpb/es/daw/rest/dto/request/AuthRequestDTO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/dto/request/AuthRequestDTO.java
@@ -1,0 +1,13 @@
+package br.edu.ifpb.es.daw.rest.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthRequestDTO(
+        @Schema(example = "poatan@gmail.com")
+        @NotBlank @Email String email,
+
+        @Schema(example = "senha123")
+        @NotBlank String senha
+) {}

--- a/src/main/java/br/edu/ifpb/es/daw/rest/dto/response/AuthResponseDTO.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/dto/response/AuthResponseDTO.java
@@ -1,0 +1,7 @@
+package br.edu.ifpb.es.daw.rest.dto.response;
+
+public record AuthResponseDTO(
+        String token,
+        String role,
+        String email
+) {}

--- a/src/main/java/br/edu/ifpb/es/daw/rest/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/br/edu/ifpb/es/daw/rest/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package br.edu.ifpb.es.daw.rest.filter;
+
+import br.edu.ifpb.es.daw.service.JwtService;
+import br.edu.ifpb.es.daw.service.UsuarioUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired private JwtService jwtService;
+    @Autowired private UsuarioUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (jwtService.isTokenValid(token)) {
+            String email = jwtService.extractEmail(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/br/edu/ifpb/es/daw/seed/SeedService.java
+++ b/src/main/java/br/edu/ifpb/es/daw/seed/SeedService.java
@@ -34,6 +34,7 @@ public class SeedService {
     private final DevolucaoRepository devolucaoRepository;
     private final AvaliacaoRepository avaliacaoRepository;
     private final PasswordEncoder passwordEncoder;
+    private final br.edu.ifpb.es.daw.config.StartupListener startupListener;
 
     public SeedService(
             AdminRepository adminRepository,
@@ -51,7 +52,8 @@ public class SeedService {
             EntregaRepository entregaRepository,
             DevolucaoRepository devolucaoRepository,
             AvaliacaoRepository avaliacaoRepository,
-            PasswordEncoder passwordEncoder) {
+            PasswordEncoder passwordEncoder,
+            br.edu.ifpb.es.daw.config.StartupListener startupListener) {
 
         this.adminRepository = adminRepository;
         this.clienteRepository = clienteRepository;
@@ -69,6 +71,7 @@ public class SeedService {
         this.devolucaoRepository = devolucaoRepository;
         this.avaliacaoRepository = avaliacaoRepository;
         this.passwordEncoder = passwordEncoder;
+        this.startupListener = startupListener;
     }
 
     @Transactional
@@ -88,6 +91,9 @@ public class SeedService {
         clienteRepository.deleteAll();
         vendedorRepository.deleteAll();
         adminRepository.deleteAll();
+
+        // Garante que o admin padrão sempre exista, mesmo após limpar tudo
+        startupListener.criarAdminPadraoSeNaoExistir();
     }
 
     @Transactional

--- a/src/main/java/br/edu/ifpb/es/daw/service/JwtService.java
+++ b/src/main/java/br/edu/ifpb/es/daw/service/JwtService.java
@@ -1,0 +1,63 @@
+package br.edu.ifpb.es.daw.service;
+
+import br.edu.ifpb.es.daw.model.enums.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${app.jwt.secret}")
+    private String secret;
+
+    @Value("${app.jwt.expiration}")
+    private long expiration;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(String email, Role role) {
+        return Jwts.builder()
+                .subject(email)
+                .claim("role", role.name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public Role extractRole(String token) {
+        String roleStr = getClaims(token).get("role", String.class);
+        return Role.valueOf(roleStr);
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/br/edu/ifpb/es/daw/service/UsuarioUserDetailsService.java
+++ b/src/main/java/br/edu/ifpb/es/daw/service/UsuarioUserDetailsService.java
@@ -1,0 +1,29 @@
+package br.edu.ifpb.es.daw.service;
+
+import br.edu.ifpb.es.daw.model.Usuario;
+import br.edu.ifpb.es.daw.repository.UsuarioRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UsuarioUserDetailsService implements UserDetailsService {
+
+    @Autowired private UsuarioRepository usuarioRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario nao encontrado"));
+
+        return User.builder()
+                .username(usuario.getEmail())
+                .password(usuario.getSenha())
+                .authorities(usuario.getRole().name()) // PADRÃO: ADMIN, CLIENTE, VENDEDOR (Sem prefixo ROLE_)
+                .accountLocked(!usuario.isAtivo())
+                .build();
+    }
+}


### PR DESCRIPTION


# Pull Request: Implementação de Autenticação JWT, Segurança e Seed de Dados

## 🎯 Resumo
Este PR implementa o fluxo completo de segurança da aplicação, abrangendo desde a geração de tokens JWT até o controle de acesso granular nos endpoints (RBAC) e ferramentas para desenvolvedores (Seed).

**Issues vinculadas:**
* Closes #48
* Closes #49
* Closes #50

---

## 🛠️ Alterações Realizadas

### 🔐 Autenticação e JWT (#48)
- Adição das dependências do **JJWT** (0.12.6) para manipulação de tokens.
- Implementação do `JwtService` para geração, extração de claims e validação de tokens.
- Criação do `AuthController` com o endpoint `/auth/login`, retornando o token e o perfil do usuário.
- Definição dos DTOs de Request e Response para o processo de autenticação.

### 🛡️ Configuração de Segurança e Filtros (#49)
- Implementação do `JwtAuthenticationFilter` para interceptação stateless de cada requisição.
- Criação do `UsuarioUserDetailsService` para integração do nosso modelo de `Usuario` com o Spring Security.
- Configuração do `SecurityConfiguration`:
    - Definidas rotas públicas (`/auth/login`, cadastro de clientes/vendedores, Swagger).
    - Ativada segurança de nível de método (`@PreAuthorize`).
    - Padronização do uso de **Authorities** para evitar conflitos de prefixo (`ROLE_`).
- Atualização do `SpringDocConfiguration` para permitir o uso de tokens via interface do Swagger.

### 📋 Proteção de Recursos
- Aplicação de anotações `@PreAuthorize` em todos os Controllers do sistema, garantindo que:
    - **ADMIN:** Possui acesso total.
    - **VENDEDOR:** Gerencia seus produtos e visualiza dados permitidos.
    - **CLIENTE:** Realiza pedidos e gerencia seu perfil.

### 🌱 Infraestrutura de Testes e Seed (#50)
- Implementação do `StartupListener` para criação automática de um **Admin Padrão** no primeiro boot.
- Criação do `SeedService` e `SeedController` para popular e limpar o banco de dados via API (restrito a ADMIN).
- Facilitação do ambiente de desenvolvimento com carga inicial de categorias, produtos e usuários.

---

## 🚦 Como Testar
1. Suba a aplicação: `mvn spring-boot:run`.
2. Verifique no log do console a criação do admin padrão.
3. Acesse o Swagger: `http://localhost:8080/swagger-ui/index.html`.
4. Realize o login em `/auth/login` com as credenciais `admin@marketplace.com` / `admin123`.
5. Copie o token retornado e clique no botão **Authorize** no topo do Swagger, cole o token no campo `bearer-jwt`.
6. Teste o endpoint `POST /seed/popular` para carregar dados de teste.
7. Tente acessar endpoints protegidos (ex: `GET /clientes`) com e sem o token para validar as permissões.

---
**Nota Técnica:** Foi corrigida a inconsistência entre o uso de `hasRole` e `hasAuthority`, optando-se por Authorities puras para simplificar a integração com o banco de dados e evitar o prefixo automático `ROLE_` do Spring Security.